### PR TITLE
Fix broken hyperlinks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Please read [`CODE_OF_CONDUCT.md`][code-of-conduct] before contributing.
 
 ## Getting started
 
-To start contributing, first ensure your system meets the [requirements][readme-requirements]. Next, install the
+To start contributing, first ensure your system meets the [requirements][readme-requirements-to-create-a-cookiecutter-template]. Next, install the
 required Python packages, and [pre-commit hooks][pre-commit] using:
 
 ```shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Please read [`CODE_OF_CONDUCT.md`][code-of-conduct] before contributing.
 
 ## Getting started
 
-To start contributing, first ensure your system meets the [requirements][readme-requirements-to-create-a-cookiecutter-template]. Next, install the
+To start contributing, first ensure your system meets the [requirements][readme-requirements]. Next, install the
 required Python packages, and [pre-commit hooks][pre-commit] using:
 
 ```shell
@@ -113,4 +113,4 @@ Further information on how to write Sphinx documentation, and how to build it in
 [myst]: https://myst-parser.readthedocs.io/
 [pre-commit]: https://pre-commit.com/
 [pytest]: https://docs.pytest.org/
-[readme-requirements]: ./README.md#requirements
+[readme-requirements]: ./README.md#requirements-to-create-a-cookiecutter-template

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A cookiecutter template for analytical, code-based projects within Her Majesty's Government.
 
 - [Who/what is this for?](#whowhat-is-this-for)
-- [Getting started](#getting-started)
-  - [Requirements](#requirements)
+- [Getting started](#getting-started-with-govcookiecutter-for-your-projects)
+  - [Requirements](#requirements-to-create-a-cookiecutter-template)
 - [Changes to make post-creation](#changes-to-make-post-creation)
 - [Changes to consider post-creation](#changes-to-consider-post-creation)
 - [Licence](#licence)
@@ -35,7 +35,7 @@ Jupyter notebook outputs for security purposes.
 > ⚠️ Only Unix-based systems (macOS, Linux, ...), and Python projects for GitHub or GitLab are supported — feel free to
 > [contribute](#contributing) to support other operating systems/programming languages!
 
-To use this template to start your next coding project, make sure your system meets the [requirements](#requirements).
+To use this template to start your next coding project, make sure your system meets the [requirements](#requirements-to-create-a-cookiecutter-template).
 
 Once you're all set up, open your terminal, navigate to the directory where you want your new repository to exist, and
 run the following commands:


### PR DESCRIPTION
Realised that with the last PR, two sub-section headings in the root `README.md` were changed and that broke a few internal hyperlinks in the root `README.md` and `CONTRIBUTING.md` files. This PR fixes them.