### PR TITLE
Make `.secrets` creation mandatory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: master
+    rev: 3.8.4
     hooks:
     -   id: flake8
         args: ["hooks", "tests", "{{ cookiecutter.repo_name }}/src"]
 -   repo: https://github.com/Yelp/detect-secrets
-    rev: v0.13.1
+    rev: v0.14.3
     hooks:
     -   id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
@@ -21,7 +21,7 @@ repos:
         -   --pin-patterns
         -   "[keep_output]"
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.4.0
     hooks:
     -   id: check-added-large-files
         args: ["--maxkb=5120"]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,10 @@
 {
+  "custom_plugin_paths": [],
   "exclude": {
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-10-28T08:52:26Z",
+  "generated_at": "2021-01-11T09:41:31Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -58,7 +59,7 @@
     }
   ],
   "results": {},
-  "version": "0.13.1",
+  "version": "0.14.3",
   "word_list": {
     "file": null,
     "hash": null

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -15,13 +15,14 @@ Where this Code of Conduct says:
 
 - "Project", we mean this `govcookiecutter` GitHub repository;
 - "Maintainer", we mean the `ukgovdatascience` organisation owners; and
-- "Leadership", we mean both `ukgovdatascience` organisation owners, line managers, and other leadership within GDS.
+- "Leadership", we mean both `ukgovdatascience` organisation owners, line managers, and other leadership within the
+  Government Digital Service.
 
 ### Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make
-participation in our project and our community a harassment-free experience for everyone, regardless of age, body size,
-disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education,
+participation in our project, and our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education,
 socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 ### Our Standards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,9 @@ make requirements
 It is better to use the above make command, rather than `pip install -r requirements.txt` and `pre-commit install`, as
 the command will ensure your pre-commit hooks are up-to-date with any changes made.
 
-The pre-commit hooks are a security feature to ensure no secrets, large data files, and output cells of Jupyter
-notebooks are accidentally committed into the repository. For more information about the pre-commit hooks used in this
-repository, see the [documentation][docs-pre-commit-hooks].
+The pre-commit hooks are a security feature to ensure no secrets<sup>[1](#footnote-1)</sup>, large data files, and
+Jupyter notebooks are accidentally committed into the repository. For more information about the pre-commit hooks used
+in this repository, see the [documentation][docs-pre-commit-hooks].
 
 ## Code conventions
 
@@ -100,9 +100,15 @@ unless it's more appropriate to store it elsewhere, like this file.
 Further information on how to write Sphinx documentation, and how to build it into a searchable website can be found
 [here][docs-write-sphinx-documentation].
 
+---
+
+<a name="footnote-1">[1]</a>: Only secrets of specific patterns are detected by the pre-commit hooks. See
+[here][docs-pre-commit-hooks-secrets-definition] for further details.
+
 [code-of-conduct]: ./CODE_OF_CONDUCT.md
 [coverage]: https://coverage.readthedocs.io/
 [docs-pre-commit-hooks]: ./%7B%7B%20cookiecutter.repo_name%20%7D%7D/docs/contributor_guide/pre_commit_hooks.md
+[docs-pre-commit-hooks-secrets-definition]: ./%7B%7B%20cookiecutter.repo_name%20%7D%7D/docs/contributor_guide/pre_commit_hooks.md#definition-of-a-secret-according-to-detect-secrets
 [docs-updating-gitignore]: ./%7B%7B%20cookiecutter.repo_name%20%7D%7D/docs/contributor_guide/updating_gitignore.md
 [docs-write-sphinx-documentation]: ./%7B%7B%20cookiecutter.repo_name%20%7D%7D/docs/contributor_guide/writing_sphinx_documentation.md
 [email]: mailto:gdsdatascience@digital.cabinet-office.gov.uk

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ It is better to use the above make command, rather than `pip install -r requirem
 the command will ensure your pre-commit hooks are up-to-date with any changes made.
 
 The pre-commit hooks are a security feature to ensure no secrets<sup>[1](#footnote-1)</sup>, large data files, and
-Jupyter notebooks are accidentally committed into the repository. For more information about the pre-commit hooks used
+Jupyter notebook outputs are accidentally committed into the repository. For more information about the pre-commit hooks used
 in this repository, see the [documentation][docs-pre-commit-hooks].
 
 ## Code conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Use a local link to reference the [`README.md`](./README.md) file, but an extern
 [gov-uk]: https://www.gov.uk/
 ```
 
-We also try and wrap Markdown to a line length of 120 characters, but this is not strictly enforced in all cases, for
+We also try to wrap Markdown to a line length of 120 characters, but this is not strictly enforced in all cases, for
 example with long hyperlinks.
 
 ## Testing
@@ -83,7 +83,7 @@ Code coverage of Python scripts is measured using the [`coverage`][coverage] Pyt
 found in `.coveragerc`. Note coverage only extends to Python scripts in the `hooks`, and
 `{{ cookiecutter.repo_name }}/src` folders.
 
-To run code coverage, and view it as a HTML report, execute the following commands in your terminal:
+To run code coverage, and view it as an HTML report, execute the following commands in your terminal:
 
 ```shell
 coverage run -m pytest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
-.PHONY: docs docs_check_external_links example example_with_options help prepare_docs_folder prepare_example_folder requirements
+.PHONY:
+	docs
+	docs_check_external_links
+	example
+	example_with_options
+	help
+	prepare_docs_folder
+	prepare_example_folder
+	requirements
 
 .DEFAULT_GOAL := help
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Jupyter notebook outputs for security purposes.
 > ⚠️ Only Unix-based systems (macOS, Linux, ...), and Python projects for GitHub or GitLab are supported — feel free to
 > [contribute](#contributing) to support other operating systems/programming languages!
 
-To use this template to start your next coding project, make sure your system meets the [requirements](#requirements-to-create-a-cookiecutter-template).
+To use this template to start your next coding project, make sure your system meets the
+[requirements](#requirements-to-create-a-cookiecutter-template).
 
 Once you're all set up, open your terminal, navigate to the directory where you want your new repository to exist, and
 run the following commands:

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ We use nudges, such as checklists in pull/merge requests, to minimise the burden
 complete AQA checks. This results in faster iterative development and deployment, whilst ensuring HM Government-wide
 standards on assurance are met.
 
-We have also included [pre-commit hooks][pre-commit] to prevent accidental committing of secrets, large data files, and
-Jupyter notebook outputs for security purposes.
+We have also included [pre-commit hooks][pre-commit] to prevent accidental committing of
+secrets<sup>[1](#footnote-1)</sup>, large data files, and Jupyter notebook outputs for security purposes.
 
 ## Getting started with `govcookiecutter` for your projects
 
@@ -118,8 +118,14 @@ If you want to help us build, and improve `govcookiecutter`, view our [contribut
 This template is based off the [DrivenData Cookiecutter Data Science][drivendata] project, especially around the
 template data and src folder structures, and the `make help` commands in the Makefiles.
 
+---
+
+<a name="footnote-1">[1]</a>: Only secrets of specific patterns are detected by the pre-commit hooks. See
+[here][docs-pre-commit-hooks-secrets-definition] for further details.
+
 [aqua-book]: https://www.gov.uk/government/publications/the-aqua-book-guidance-on-producing-quality-analysis-for-government
 [aqua-book-resources]: https://www.gov.uk/government/collections/aqua-book-resources
+[docs-pre-commit-hooks-secrets-definition]: ./%7B%7B%20cookiecutter.repo_name%20%7D%7D/docs/contributor_guide/pre_commit_hooks.md#definition-of-a-secret-according-to-detect-secrets
 [contributing]: ./CONTRIBUTING.md
 [cookiecutter]: https://github.com/cookiecutter/cookiecutter
 [drivendata]: http://drivendata.github.io/cookiecutter-data-science/

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,6 +10,5 @@
   "project_name": "Your new project name",
   "repo_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
   "overview": "Brief overview of your project.",
-  "project_version": "0.0.1",
-  "create_secrets_file": ["No", "Yes"]
+  "project_version": "0.0.1"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,5 +1,4 @@
 from shutil import rmtree
-from textwrap import dedent
 import os
 
 # Define the folder path to the 'docs/aqa_frameworks' folder, and the future `docs/aqa` folder
@@ -15,41 +14,6 @@ PATH_PR_MR_TEMPLATE = {
     "GitHub": [os.path.join(".github"), "pull_request_template.md"],
     "GitLab": [os.path.join(".gitlab", "merge_request_templates"), "{{ cookiecutter.project_name }}.md"]
 }
-
-
-def create_secrets_file(user_option: str) -> None:
-    """Create a .secrets file depending on a user option.
-
-    Args:
-        user_option (str): User option.
-
-    Returns:
-        A .secrets file created in the top-level if user_option is 'Yes', otherwise nothing.
-
-    """
-
-    # Check if `user_option` is 'Yes'
-    if user_option == "Yes":
-
-        # Define a header for the `.secrets file`
-        secrets_file = """
-        # Secrets go here, and can be read in by Python using `os.getenv`:
-        #
-        #   --------------------------------------------------------
-        #   import os
-        #
-        #   EXAMPLE_SECRET = os.getenv("EXAMPLE_SECRET")
-        #   --------------------------------------------------------
-        #
-        # This file is NOT version-controlled!
-
-        # Google Cloud authentication credentials
-        export GOOGLE_APPLICATION_CREDENTIALS=""
-        """
-
-        # Write the `.secrets` file out
-        with open(".secrets", "w") as f:
-            f.write(dedent(secrets_file).lstrip())
 
 
 def select_dept_aqa_framework(user_option: str, default_option: str = "GDS") -> None:
@@ -110,9 +74,6 @@ def select_pull_merge_request_template(user_option: str, repo_host: str, default
 
 
 if __name__ == "__main__":
-
-    # Create a .secrets file, if requested
-    create_secrets_file("{{ cookiecutter.create_secrets_file }}")
 
     # Select the appropriate AQA framework
     select_dept_aqa_framework("{{ cookiecutter.departmental_aqa_framework }}")

--- a/tests/test_envrc.py
+++ b/tests/test_envrc.py
@@ -4,7 +4,7 @@ import re
 # Define the cookiecutter directory
 DIR_COOKIECUTTER = "{{ cookiecutter.repo_name }}"
 
-# Initialise an empty list to store the expected filepaths
+# Initialise an empty list to store the expected file paths
 DIRS_EXPECTED = []
 
 # Get all the directories within `DIR_COOKIECUTTER`, including all sub-folders (unless they are `docs`, or

--- a/{{ cookiecutter.repo_name }}/.envrc
+++ b/{{ cookiecutter.repo_name }}/.envrc
@@ -3,6 +3,7 @@
 #   --------------------------------------------------------
 #   import os
 #
+#   # Example variable
 #   EXAMPLE_VARIABLE = os.getenv("EXAMPLE_VARIABLE")
 #   --------------------------------------------------------
 #
@@ -12,16 +13,15 @@
 # DO NOT STORE SECRETS HERE - this file is version-controlled! You should store secrets in a `.secrets` file, which is
 # not version-controlled - this can then be sourced here, using `source_env ".secrets"`.
 
-# Extract the variables to `.env` if required. Note `.env` is NOT version-controlled{% if cookiecutter.create_secrets_file == "Yes" %}, so `.secrets` will not be
-# committed{% endif %}
-sed -n 's/^export \(.*\)$/\1/p' .envrc {% if cookiecutter.create_secrets_file == "Yes" %}.secrets {% endif %}| sed -e 's?$(pwd)?'"$(pwd)"'?g' > .env
-{% if cookiecutter.create_secrets_file == "No" %}# sed -n 's/^export \(.*\)$/\1/p' .envrc .secrets | sed -e 's?$(pwd)?'"$(pwd)"'?g' > .env  # use this line instead if you have a `.secrets` file
-{% endif %}
+# Extract the variables to `.env` if required. Note `.env` is NOT version-controlled, so `.secrets` will not be
+# committed
+sed -n 's/^export \(.*\)$/\1/p' .envrc .secrets | sed -e 's?$(pwd)?'"$(pwd)"'?g' > .env
+
 # Add the working directory to PYTHONPATH; allows Jupyter notebooks in the `notebooks` folder to import `src`
 export PYTHONPATH="$PYTHONPATH:$(pwd)"
 
 # Import secrets from an untracked file `.secrets`
-{% if cookiecutter.create_secrets_file == "No" %}# {% endif %}source_env ".secrets"
+source_env ".secrets"
 
 # Add environment variables for the `data` directories
 export DIR_DATA=$(pwd)/data

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -2,12 +2,12 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: master
+    rev: 3.8.4
     hooks:
     -   id: flake8
         args: ["src"]
 -   repo: https://github.com/Yelp/detect-secrets
-    rev: v0.13.1
+    rev: v0.14.3
     hooks:
     -   id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
@@ -21,7 +21,7 @@ repos:
         -   --pin-patterns
         -   "[keep_output]"
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.4.0
     hooks:
     -   id: check-added-large-files
         args: ["--maxkb=5120"]

--- a/{{ cookiecutter.repo_name }}/.secrets
+++ b/{{ cookiecutter.repo_name }}/.secrets
@@ -1,0 +1,15 @@
+# Secrets and credentials should be stored here as environmental variables. For example:
+#
+#   # Google Cloud authentication credentials
+#   export GOOGLE_APPLICATION_CREDENTIALS="path/to/credentials.json"
+#
+# These environment variables can then be read in by Python using `os.getenv`:
+#
+#   --------------------------------------------------------
+#   import os
+#
+#   # Google Cloud authentication credentials
+#   GOOGLE_APPLICATION_CREDENTIALS = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+#   --------------------------------------------------------
+#
+# This file is NOT version-controlled!

--- a/{{ cookiecutter.repo_name }}/.secrets.baseline
+++ b/{{ cookiecutter.repo_name }}/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-10-28T08:52:26Z",
+  "generated_at": "2021-01-11T09:41:31Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/{{ cookiecutter.repo_name }}/CODE_OF_CONDUCT.md
+++ b/{{ cookiecutter.repo_name }}/CODE_OF_CONDUCT.md
@@ -22,8 +22,8 @@ Where this Code of Conduct says:
 ### Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make
-participation in our project and our community a harassment-free experience for everyone, regardless of age, body size,
-disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education,
+participation in our project, and our community a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education,
 socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 ### Our Standards

--- a/{{ cookiecutter.repo_name }}/CONTRIBUTING.md
+++ b/{{ cookiecutter.repo_name }}/CONTRIBUTING.md
@@ -28,9 +28,9 @@ make requirements
 It is better to use the above make command, rather than `pip install -r requirements.txt` and `pre-commit install`, as
 the command will ensure your pre-commit hooks are up-to-date with any changes made.
 
-The pre-commit hooks are a security feature to ensure no secrets, large data files, and Jupyter notebooks are
-accidentally committed into the repository. For more information about the pre-commit hooks used in this repository,
-see the [documentation][docs-pre-commit-hooks].
+The pre-commit hooks are a security feature to ensure no secrets<sup>[1](#footnote-1)</sup>, large data files, and
+Jupyter notebooks are accidentally committed into the repository. For more information about the pre-commit hooks used
+in this repository, see the [documentation][docs-pre-commit-hooks].
 
 ## Code conventions
 
@@ -100,9 +100,15 @@ unless it's more appropriate to store it elsewhere, like this file.
 Further information on how to write Sphinx documentation, and how to build it into a searchable website can be found
 [here][docs-write-sphinx-documentation].
 
+---
+
+<a name="footnote-1">[1]</a>: Only secrets of specific patterns are detected by the pre-commit hooks. See
+[here][docs-pre-commit-hooks-secrets-definition] for further details.
+
 [code-of-conduct]: ./CODE_OF_CONDUCT.md
 [coverage]: https://coverage.readthedocs.io/
 [docs-pre-commit-hooks]: ./docs/contributor_guide/pre_commit_hooks.md
+[docs-pre-commit-hooks-secrets-definition]: ./docs/contributor_guide/pre_commit_hooks.md#definition-of-a-secret-according-to-detect-secrets
 [docs-updating-gitignore]: ./docs/contributor_guide/updating_gitignore.md
 [docs-write-sphinx-documentation]: ./docs/contributor_guide/writing_sphinx_documentation.md
 [email]: mailto:{{ cookiecutter.contact_email }}

--- a/{{ cookiecutter.repo_name }}/CONTRIBUTING.md
+++ b/{{ cookiecutter.repo_name }}/CONTRIBUTING.md
@@ -29,7 +29,7 @@ It is better to use the above make command, rather than `pip install -r requirem
 the command will ensure your pre-commit hooks are up-to-date with any changes made.
 
 The pre-commit hooks are a security feature to ensure no secrets<sup>[1](#footnote-1)</sup>, large data files, and
-Jupyter notebooks are accidentally committed into the repository. For more information about the pre-commit hooks used
+Jupyter notebook outputs are accidentally committed into the repository. For more information about the pre-commit hooks used
 in this repository, see the [documentation][docs-pre-commit-hooks].
 
 ## Code conventions

--- a/{{ cookiecutter.repo_name }}/CONTRIBUTING.md
+++ b/{{ cookiecutter.repo_name }}/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Use a local link to reference the [`README.md`](./README.md) file, but an extern
 [gov-uk]: https://www.gov.uk/
 ```
 
-We also try and wrap Markdown to a line length of 120 characters, but this is not strictly enforced in all cases, for
+We also try to wrap Markdown to a line length of 120 characters, but this is not strictly enforced in all cases, for
 example with long hyperlinks.
 
 ## Testing
@@ -83,7 +83,7 @@ Code coverage of Python scripts is measured using the [`coverage`][coverage] Pyt
 found in `.coveragerc`. Note coverage only extends to Python scripts in the `hooks`, and
 `{{ cookiecutter.repo_name }}/src` folders.
 
-To run code coverage, and view it as a HTML report, execute the following commands in your terminal:
+To run code coverage, and view it as an HTML report, execute the following commands in your terminal:
 
 ```shell
 coverage run -m pytest

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -1,4 +1,9 @@
-.PHONY: docs docs_check_external_links help prepare_docs_folder requirements
+.PHONY:
+	docs
+	docs_check_external_links
+	help
+	prepare_docs_folder
+	requirements
 
 .DEFAULT_GOAL := help
 

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -49,7 +49,7 @@ If you want to help us build, and improve `{{ cookiecutter.project_name }}`, vie
 
 ## Acknowledgements
 
-This project structure is based on the `govcookiecutter` template project.
+This project structure is based on the [`govcookiecutter`][govcookiecutter] template project.
 
 [contributing]: ./CONTRIBUTING.md
 [govcookiecutter]: https://github.com/ukgovdatascience/govcookiecutter

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -6,7 +6,7 @@
 
 - [Getting started](#getting-started)
   - [Requirements](#requirements)
-{% if cookiecutter.create_secrets_file == "Yes" %}- [Required secrets and credentials](#required-secrets-and-credentials){% endif -%}
+- [Required secrets and credentials](#required-secrets-and-credentials)
 - [Licence](#licence)
 - [Contributing](#contributing)
 - [Acknowledgements](#acknowledgements)
@@ -17,11 +17,11 @@ To be added.
 
 ### Requirements
 
-{% if cookiecutter.create_secrets_file == "Yes" %}- A `.secrets` file with the [required secrets and credentials](#required-secrets-and-credentials){% endif -%}
+- A `.secrets` file with the [required secrets and credentials](#required-secrets-and-credentials)
 - [Load environment variables][docs-loading-environment-variables] from `.envrc`
 
 To be added.
-{% if cookiecutter.create_secrets_file == "Yes" %}
+
 ## Required secrets and credentials
 
 To run this project, you need a `.secrets` file with secrets/credentials as environmental variables; see the
@@ -35,7 +35,7 @@ the following environment variable name(s):
 
 Once you've added these environment variables to `.secrets` you will need to
 [load them via `.envrc`][docs-loading-environment-variables].
-{% endif %}
+
 ## Licence
 
 Unless stated otherwise, the codebase is released under the MIT License. This covers both the codebase and any sample

--- a/{{ cookiecutter.repo_name }}/data/README.md
+++ b/{{ cookiecutter.repo_name }}/data/README.md
@@ -1,6 +1,6 @@
 # `data` folder
 
-Any data that needs to be stored locally should be saved in this location. This folder, and all its sub-folders are not
+Any data that needs to be stored locally should be saved in this location. This folder, and its sub-folders, are not
 version-controlled.
 
 The sub-folders should be used as follows:

--- a/{{ cookiecutter.repo_name }}/docs/contributor_guide/pre_commit_hooks.md
+++ b/{{ cookiecutter.repo_name }}/docs/contributor_guide/pre_commit_hooks.md
@@ -14,12 +14,13 @@ ensuring that all of our code adheres to a certain quality standard.
 
 For this repository, we are using `pre-commit` for a number of purposes:
 
-- Checking for any secrets being committed accidentally;
+- Checking for secrets being committed accidentally — see [here](#definition-of-a-secret-according-to-detect-secrets)
+  for the definition of a "secret";
 - Checking for any large files (over 5 MB) being committed; and
 - Cleaning Jupyter notebooks, which means removing all outputs and execution counts.
 
 We have configured `pre-commit` to run automatically on _every commit_. By running on each commit, we ensure that
-`pre-commit` will be able to detect all contraventions and keep our repo in a healthy state.
+`pre-commit` will be able to detect all contraventions and keep our repository in a healthy state.
 
 ## Installation
 
@@ -30,9 +31,14 @@ In order for `pre-commit` to run, action is needed to configure it on your syste
 
 ## Using the `detect-secrets` pre-commit hook
 
-We use [`detect-secrets`][detect-secrets] to check that no secrets are accidentally committed. This hook requires you
-to generate a baseline file if one is not already present within the root directory. To create the baseline file, run
-the following at the root of the repository:
+> ⚠️ The `detect-secrets` package does its best to prevent accidental committing of secrets, but it can't catch
+> everything. **It doesn't replace good software development practices!** See the definition of a secret
+> [here](#definition-of-a-secret-according-to-detect-secrets) for further information.
+
+We use [`detect-secrets`][detect-secrets] to check that no secrets, as defined
+[here](#definition-of-a-secret-according-to-detect-secrets), are accidentally committed. This hook requires you to
+generate a baseline file if one is not already present within the root directory. To create the baseline file, run the
+following at the root of the repository:
 
 ```shell
 detect-secrets scan > .secrets.baseline
@@ -46,8 +52,24 @@ detect-secrets audit .secrets.baseline
 
 When you run this command, you'll enter an interactive console and be presented with a list of high-entropy string
 and/or anything which _could_ be a secret, and asked to verify whether this is the case. By doing this, the hook will
-be in a position to know if you're later committing any _new_ secrets to the repo, and it will be able to alert you
-accordingly.
+be in a position to know if you're later committing any _new_ secrets to the repository, and it will be able to alert
+you accordingly.
+
+### Definition of a "secret" according to `detect-secrets`
+
+The [`detect-secrets` documentation][detect-secrets], as of January 2021, says it works:
+
+> ...by running periodic diff outputs against heuristically crafted \[regular expression\] statements, to identify
+> whether any new secret has been committed.
+
+This means it uses regular expression patterns to scan your code changes for anything that **looks like a secret
+according to one or more of these regular expression patterns**. By definition, there are only a limited number of
+patterns, so the `detect-secrets` package cannot detect every conceivable type of secret.
+
+To understand what types of secrets will be detected, read the [caveats][detect-secrets-caveats], and the list of
+[supported plugins][detect-secrets-plugins] that the package uses. Also, you should use secret variable names that
+contain words that will trip the KeywordDetector plugin; see the `DENYLIST` variable
+[here][detect-secrets-keyword-detector] for the full list of words.
 
 ### If `pre-commit` detects secrets during commit
 
@@ -81,4 +103,7 @@ visualising some set of data. To do this, add the following comment at the top o
 This will tell the hook not to strip the resulting output of this cell, allowing it to be committed.
 
 [detect-secrets]: https://github.com/Yelp/detect-secrets
+[detect-secrets-caveats]: https://github.com/Yelp/detect-secrets#caveats
+[detect-secrets-keyword-detector]: https://github.com/Yelp/detect-secrets/blob/master/detect_secrets/plugins/keyword.py
+[detect-secrets-plugins]: https://github.com/Yelp/detect-secrets#currently-supported-plugins
 [pre-commit]: https://pre-commit.com/

--- a/{{ cookiecutter.repo_name }}/docs/contributor_guide/pre_commit_hooks.md
+++ b/{{ cookiecutter.repo_name }}/docs/contributor_guide/pre_commit_hooks.md
@@ -15,7 +15,7 @@ ensuring that all of our code adheres to a certain quality standard.
 For this repository, we are using `pre-commit` for a number of purposes:
 
 - Checking for any secrets being committed accidentally;
-- Checking for any large files (over 5MB) being committed; and
+- Checking for any large files (over 5 MB) being committed; and
 - Cleaning Jupyter notebooks, which means removing all outputs and execution counts.
 
 We have configured `pre-commit` to run automatically on _every commit_. By running on each commit, we ensure that
@@ -26,7 +26,7 @@ We have configured `pre-commit` to run automatically on _every commit_. By runni
 In order for `pre-commit` to run, action is needed to configure it on your system.
 
 - Install the `pre-commit` package into your Python environment from `requirements.txt`; and
-- Run `pre-commit install` in your terminal to set-up `pre-commit` to run when code is _committed_.
+- Run `pre-commit install` in your terminal to set up `pre-commit` to run when code is _committed_.
 
 ## Using the `detect-secrets` pre-commit hook
 
@@ -45,8 +45,8 @@ detect-secrets audit .secrets.baseline
 ```
 
 When you run this command, you'll enter an interactive console and be presented with a list of high-entropy string
-and/or anything which _could_ be a secret, and asked to verify whether or not this is the case. By doing this, the hook
-will be in a position to know if you're later committing any _new_ secrets to the repo and it will be able to alert you
+and/or anything which _could_ be a secret, and asked to verify whether this is the case. By doing this, the hook will
+be in a position to know if you're later committing any _new_ secrets to the repo, and it will be able to alert you
 accordingly.
 
 ### If `pre-commit` detects secrets during commit
@@ -64,10 +64,10 @@ If the detected secret is a false-positive, you should update the `.secrets.base
   been updated for.
 
 If the detected secret is actually a secret (or other sensitive information), remove the secret and re-commit. There is
-no need to update the secrets baseline in this case.
+no need to update the `.secrets.baseline` file in this case.
 
 If your commit contains a mixture of false-positives and actual secrets, remove the actual secrets first before
-updating and auditing the secrets baseline.
+updating and auditing the `.secrets.baseline` file.
 
 ## Keeping specific Jupyter notebook outputs
 

--- a/{{ cookiecutter.repo_name }}/docs/contributor_guide/writing_sphinx_documentation.md
+++ b/{{ cookiecutter.repo_name }}/docs/contributor_guide/writing_sphinx_documentation.md
@@ -35,7 +35,7 @@ project:
 make docs
 ```
 
-This should create a HTML version of your documentation accessible from `docs/_build/index.html`.
+This should create an HTML version of your documentation accessible from `docs/_build/index.html`.
 
 ## Writing in reStructuredText
 
@@ -102,9 +102,9 @@ stub files.
 ```
 ````
 
-### Including Markdown files outside of the `docs` folder
+### Including Markdown files outside the `docs` folder
 
-MyST lets you include Markdown files outside of the `docs` folder [easily][myst-include].
+MyST lets you include Markdown files outside the `docs` folder [easily][myst-include].
 
 If a Markdown file (`../example.md`) only contains links that do not reference anything else in this project (including
 images), create a Markdown file within the `docs` folder with the following lines:

--- a/{{ cookiecutter.repo_name }}/docs/structure/README.md
+++ b/{{ cookiecutter.repo_name }}/docs/structure/README.md
@@ -45,14 +45,11 @@ A file containing environment variables for the Git repository that can be selec
 
 This file contains a `sed` command to output a `.env` file with all the environment variables. This may be useful for
 sourcing environment variables, for example in conjunction with PyCharm's EnvFile plugin.
-{% if cookiecutter.create_secrets_file == "Yes" %}
+
 To ensure this `sed` command works correctly, make sure any file paths listed in this file, and the
 [`.secrets`](#secrets) are absolute file paths, or relative file paths that do not use other environment variables.
 For example:
-{% else %}
-To ensure this `sed` command works correctly, make sure any file paths listed in this file are absolute file paths, or
-relative file paths that do not use other environment variables. For example:
-{% endif %}
+
 ```shell
 export DIR_DATA=$(pwd)/data  # fine
 export DIR_DATA_EXTERNAL=$(pwd)/data/external  # fine
@@ -73,12 +70,12 @@ A `.gitignore` file to ignore certain files and folders from this Git repository
 ### `.pre-commit-config.yaml`
 
 A pre-commit hook configuration file. See the [contributor guide][docs-pre-commit-hooks] for further details.
-{% if cookiecutter.create_secrets_file == "Yes" %}
+
 ### `.secrets`
 
 A file to store all secrets and credentials as environment variables. This is read-in by [`.envrc`](#envrc) using the
 [`direnv`][direnv] shell extension, but is **not** tracked by Git.
-{% endif %}
+
 ### `.secrets.baseline`
 
 Baseline file for the [`detect-secrets`][detect-secrets] package; this package detects secrets, and, in conjunction

--- a/{{ cookiecutter.repo_name }}/docs/user_guide/loading_environment_variables.md
+++ b/{{ cookiecutter.repo_name }}/docs/user_guide/loading_environment_variables.md
@@ -11,7 +11,8 @@ with identically named variables.
 
 ## Using `direnv`
 
-To load the environment variables, first [install `direnv`](#installing-direnv){% if cookiecutter.create_secrets_file == "Yes" %}, and make sure you have a `.secrets` file to [store secrets and credentials](#storing-secrets-and-credentials){% endif %}; then:
+To load the environment variables, first [install `direnv`](#installing-direnv), and make sure you have a `.secrets`
+file to [store secrets and credentials](#storing-secrets-and-credentials). Then:
 
 1. Open your terminal;
 2. Navigate to the project folder; and
@@ -24,7 +25,7 @@ To load the environment variables, first [install `direnv`](#installing-direnv){
    direnv allow
    ```
 
-You only need to do this **once**, and again each time `.envrc` {% if cookiecutter.create_secrets_file == "No" %}is{% else %}and `.secrets` are{% endif %} modified.
+You only need to do this **once**, and again each time `.envrc` and `.secrets` are modified.
 
 ### Installing `direnv`
 
@@ -45,7 +46,7 @@ of installing `direnv`, and its shell hooks, consult the package's [documentatio
    cat ~/.bash_profile
    ```
    - This should display `eval "$(direnv hook bash)"`
-5. Restart your terminal.{% if cookiecutter.create_secrets_file == "Yes" %}
+5. Restart your terminal.
 
 ## Storing secrets and credentials
 
@@ -71,7 +72,7 @@ Once complete, make sure the `.secrets` file has the following line uncommented 
 source_env ".secrets"
 ```
 
-This ensures [`direnv`][direnv] loads the `.secrets` file via `.envrc` **without** version-controlling `.secrets`.{% endif %}
+This ensures [`direnv`][direnv] loads the `.secrets` file via `.envrc` **without** version-controlling `.secrets`.
 
 [direnv]: https://direnv.net/
 [homebrew]: https://brew.sh/

--- a/{{ cookiecutter.repo_name }}/docs/user_guide/loading_environment_variables.md
+++ b/{{ cookiecutter.repo_name }}/docs/user_guide/loading_environment_variables.md
@@ -1,7 +1,7 @@
 # Loading environment variables
 
 We use [`direnv`][direnv] to load environment variables, as it ensures you only have project-specific variables loaded
-_when you are inside the project_, otherwise these variables are not loaded. This can prevents accidental conflicts
+_when you are inside the project_, otherwise these variables are not loaded. This can prevent accidental conflicts
 with identically named variables.
 
 ```{contents}

--- a/{{ cookiecutter.repo_name }}/src/README.md
+++ b/{{ cookiecutter.repo_name }}/src/README.md
@@ -13,7 +13,7 @@ The sub-folders should be used as follows:
 
 Feel free to create/rename/delete these folders as required, as they will not be necessary for each and every project.
 
-It is strongly suggested that you import functions in the `src` `__init__.py` script. You should also try and use
+It is strongly suggested that you import functions in the `src` `__init__.py` script. You should also try to use
 absolute imports in this script whenever possible; relative imports are not discouraged, but can be an issue for
 projects where the directory structure is likely to change. See [PEP 328][pep-328] for further information.
 


### PR DESCRIPTION
On reflection and discussion with @exfalsoquodlibet and @avisionh from comments in PR #10, we will always need to store some sort of credentials.

I've updated `govcookiecutter` with the following:

- Removed option to not create a `.secrets` file - this should now always happen
- Version-controlled here a `.secrets` file - **this will be ignored when the user creates a new template**
- Updated the documentation
- Added in caveats around the `detect-secrets` package, as highlighted through discussions with users
- Updated the package versions for the hooks to the latest release tag only