### PR TITLE
Fix incorrect `cookiecutter` variable usage in Markdown documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ It is better to use the above make command, rather than `pip install -r requirem
 the command will ensure your pre-commit hooks are up-to-date with any changes made.
 
 The pre-commit hooks are a security feature to ensure no secrets<sup>[1](#footnote-1)</sup>, large data files, and
-Jupyter notebook outputs are accidentally committed into the repository. For more information about the pre-commit hooks used
-in this repository, see the [documentation][docs-pre-commit-hooks].
+Jupyter notebook outputs are accidentally committed into the repository. For more information about the pre-commit
+hooks used in this repository, see the [documentation][docs-pre-commit-hooks].
 
 ## Code conventions
 

--- a/docs/structure/{{ cookiecutter.repo_name }}.md
+++ b/docs/structure/{{ cookiecutter.repo_name }}.md
@@ -1,4 +1,4 @@
-# {{ cookiecutter.repo_name }} repository structure
+# `{{ cookiecutter.repo_name }}` repository structure
 
 For information on the structure of the `{{ cookiecutter.repo_name }}` template folder, see the corresponding
 documentation that can be found at `{{ cookiecutter.repo_name }}/docs/structure/README.md`.

--- a/{{ cookiecutter.repo_name }}/.envrc
+++ b/{{ cookiecutter.repo_name }}/.envrc
@@ -17,7 +17,7 @@
 # committed
 sed -n 's/^export \(.*\)$/\1/p' .envrc .secrets | sed -e 's?$(pwd)?'"$(pwd)"'?g' > .env
 
-# Add the working directory to PYTHONPATH; allows Jupyter notebooks in the `notebooks` folder to import `src`
+# Add the working directory to `PYTHONPATH`; allows Jupyter notebooks in the `notebooks` folder to import `src`
 export PYTHONPATH="$PYTHONPATH:$(pwd)"
 
 # Import secrets from an untracked file `.secrets`

--- a/{{ cookiecutter.repo_name }}/CODE_OF_CONDUCT.md
+++ b/{{ cookiecutter.repo_name }}/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Code of conduct for `{{ cookiecutter.project_name }}`
+# Code of conduct for `{{ cookiecutter.repo_name }}`
 
 Contributors to this repository hosted by `{{ cookiecutter.organisation_name }}` are expected to follow the Contributor
 Covenant Code of Conduct, and those working within Her Majesty's Government are also expected to follow the Civil
@@ -14,7 +14,7 @@ The Civil Service Code can be found [here][civil-service-code].
 
 Where this Code of Conduct says:
 
-- "Project", we mean this `{{ cookiecutter.project_name }}` {{ cookiecutter.repository_hosting_platform }} repository;
+- "Project", we mean this `{{ cookiecutter.repo_name }}` {{ cookiecutter.repository_hosting_platform }} repository;
 - "Maintainer", we mean the `{{ cookiecutter.organisation_name }}` organisation owners; and
 - "Leadership", we mean both `{{ cookiecutter.organisation_name }}` organisation owners, line managers, and other
   leadership within {{ cookiecutter.department_name }}.

--- a/{{ cookiecutter.repo_name }}/CONTRIBUTING.md
+++ b/{{ cookiecutter.repo_name }}/CONTRIBUTING.md
@@ -70,8 +70,7 @@ example with long hyperlinks.
 ## Testing
 
 Tests are written using the [pytest][pytest] framework, with its configuration in the `pytest.ini` file. Note, only
-tests in the `tests`, and `{{ cookiecutter.repo_name }}/tests` folders are executed. To run the tests, execute the
-following command in your terminal:
+tests in the `tests` folder are executed. To run the tests, execute the following command in your terminal:
 
 ```shell
 pytest
@@ -80,8 +79,7 @@ pytest
 ### Code coverage
 
 Code coverage of Python scripts is measured using the [`coverage`][coverage] Python package; its configuration can be
-found in `.coveragerc`. Note coverage only extends to Python scripts in the `hooks`, and
-`{{ cookiecutter.repo_name }}/src` folders.
+found in `.coveragerc`. Note coverage only extends to Python scripts in the `src` folder.
 
 To run code coverage, and view it as an HTML report, execute the following commands in your terminal:
 

--- a/{{ cookiecutter.repo_name }}/CONTRIBUTING.md
+++ b/{{ cookiecutter.repo_name }}/CONTRIBUTING.md
@@ -29,8 +29,8 @@ It is better to use the above make command, rather than `pip install -r requirem
 the command will ensure your pre-commit hooks are up-to-date with any changes made.
 
 The pre-commit hooks are a security feature to ensure no secrets<sup>[1](#footnote-1)</sup>, large data files, and
-Jupyter notebook outputs are accidentally committed into the repository. For more information about the pre-commit hooks used
-in this repository, see the [documentation][docs-pre-commit-hooks].
+Jupyter notebook outputs are accidentally committed into the repository. For more information about the pre-commit
+hooks used in this repository, see the [documentation][docs-pre-commit-hooks].
 
 ## Code conventions
 

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -1,4 +1,4 @@
-# `{{ cookiecutter.project_name }}`
+# `{{ cookiecutter.repo_name }}`
 
 {{ cookiecutter.overview }}
 
@@ -44,7 +44,7 @@ code in the documentation. The documentation is © Crown copyright and available
 
 ## Contributing
 
-If you want to help us build, and improve `{{ cookiecutter.project_name }}`, view our
+If you want to help us build, and improve `{{ cookiecutter.repo_name }}`, view our
 [contributing guidelines][contributing].
 
 ## Acknowledgements

--- a/{{ cookiecutter.repo_name }}/docs/index.md
+++ b/{{ cookiecutter.repo_name }}/docs/index.md
@@ -1,6 +1,6 @@
-# {{ cookiecutter.project_name }} documentation
+# `{{ cookiecutter.repo_name }}` documentation
 
-Here is the documentation for the {{ cookiecutter.project_name }} project.
+Here is the documentation for the `{{ cookiecutter.repo_name }}` project.
 
 ```{toctree}
 :maxdepth: 2

--- a/{{ cookiecutter.repo_name }}/docs/structure/README.md
+++ b/{{ cookiecutter.repo_name }}/docs/structure/README.md
@@ -35,8 +35,8 @@ coverage run -m pytest
 coverage html
 ```
 
-a code coverage report in HTML will be produced on the code in the [hooks][docs-hooks], and
-`{{ cookiecutter.repo_name }}/src` folders. This HTMl report can be accessed at `htmlcov/index.html`.
+a code coverage report in HTML will be produced on the code in the `src` folder. This HTMl report can be accessed at
+`htmlcov/index.html`.
 
 ### `.envrc`
 
@@ -113,8 +113,7 @@ make help
 ### `pytest.ini`
 
 A file containing configuration settings for the [`pytest`][pytest] Python package. To run tests within the
-[`tests`][docs-tests], and `{{ cookiecutter.repo_name }}/tests` folders, execute the following
-command:
+[`tests`][docs-tests] folder, execute the following command:
 
 ```shell
 pytest


### PR DESCRIPTION
Some instances of the `project_name` variable are used, when it should be the `repo_name` variable. Fixed these instances.

Should be a very quick review - happy for this to be done by inspection, rather than code execution.