### PR TITLE
Feature: Pre-commit R

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Here's a few changes you **must** do once you've created your new project:
 
 - Set up a Python virtual environment — there are **many** ways to [set up a virtual environment][pluralsight], so
   we'll let you decide what's best for you!
-- Git is not set up by default — open your terminal, navigate to your new project, run `git init` to set it up
+- Git is not set up by default — open your terminal, navigate to your new project, run `git init` in your shell to set it up.
+- Install the packages necessary by running `make requirements` in your shell.
 
 ## Changes to consider post-creation
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,5 +12,5 @@
   "overview": "Brief overview of your project.",
   "project_version": "0.0.1",
 
-  "add_r_precommit_hooks": ["Yes", "No"]
+  "add_r_precommit_hooks": ["No", "Yes"]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,5 +10,7 @@
   "project_name": "Your new project name",
   "repo_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
   "overview": "Brief overview of your project.",
-  "project_version": "0.0.1"
+  "project_version": "0.0.1",
+
+  "add_r_precommit_hooks": ["No", "Yes"]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,5 +12,5 @@
   "overview": "Brief overview of your project.",
   "project_version": "0.0.1",
 
-  "add_r_precommit_hooks": ["No", "Yes"]
+  "add_r_precommit_hooks": ["Yes", "No"]
 }

--- a/{{ cookiecutter.repo_name }}/.Rprofile
+++ b/{{ cookiecutter.repo_name }}/.Rprofile
@@ -1,0 +1,1 @@
+source('startup.R')

--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -874,3 +874,7 @@ data/processed/*
 
 # Ignore the `.secrets` file
 .secrets
+
+# Ignore r artifacts
+*.Renviron
+*.Rhistory

--- a/{{ cookiecutter.repo_name }}/.lintr
+++ b/{{ cookiecutter.repo_name }}/.lintr
@@ -1,4 +1,4 @@
 linters: with_defaults(
-    line_length_linter(120),
+    line_length_linter = line_length_linter(120),
     commented_code_linter = NULL
     )

--- a/{{ cookiecutter.repo_name }}/.lintr
+++ b/{{ cookiecutter.repo_name }}/.lintr
@@ -1,0 +1,4 @@
+linters: with_defaults(
+    line_length_linter(120),
+    commented_code_linter = NULL
+    )

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -44,12 +44,4 @@ repos:
     -   id: readme-rmd-rendered
     -   id: parsable-R
     -   id: no-browser-statement
--   repo: local
-    hooks:
-    -   id: forbid-to-commit
-        name: Don't commit common R artifacts
-        entry: Cannot commit .Rhistory, .RData, .Rds or .rds.
-        language: fail
-        files: '\.Rhistory|\.RData|\.Rds|\.rds$|\.Renviron'
-        # `exclude: <regex>` to allow committing specific files.
 {% endif -%}

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     -   id: check-added-large-files
         args: ["--maxkb=5120"]
     -   id: end-of-file-fixer
+        exclude: '\.Rd'
     -   id: trailing-whitespace
 {% if cookiecutter.add_r_precommit_hooks == "Yes" %}
 # R specific hooks: https://github.com/lorenzwalthert/precommit
@@ -38,11 +39,11 @@ repos:
     # codemeta must be above use-tidy-description when both are used
     # -   id: codemeta-description-updated
     -   id: use-tidy-description
-    - id: lintr
-      exclude: renv/activate.R
-    - id: readme-rmd-rendered
-    - id: parsable-R
-    - id: no-browser-statement
+    -   id: lintr
+        exclude: renv/activate.R
+    -   id: readme-rmd-rendered
+    -   id: parsable-R
+    -   id: no-browser-statement
 -   repo: local
     hooks:
     -   id: forbid-to-commit

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -50,6 +50,6 @@ repos:
         name: Don't commit common R artifacts
         entry: Cannot commit .Rhistory, .RData, .Rds or .rds.
         language: fail
-        files: '\.Rhistory|\.RData|\.Rds|\.rds$'
+        files: '\.Rhistory|\.RData|\.Rds|\.rds$|\.Renviron'
         # `exclude: <regex>` to allow committing specific files.
 {% endif -%}

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -27,3 +27,28 @@ repos:
         args: ["--maxkb=5120"]
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+{% if cookiecutter.add_r_precommit_hooks == "Yes" %}
+# R specific hooks: https://github.com/lorenzwalthert/precommit
+-   repo: https://github.com/lorenzwalthert/precommit
+    rev: v0.1.2
+    hooks:
+    -   id: style-files
+        args: [--style_pkg=styler, --style_fun=tidyverse_style]
+    -   id: roxygenize
+    # codemeta must be above use-tidy-description when both are used
+    # -   id: codemeta-description-updated
+    -   id: use-tidy-description
+    - id: lintr
+      exclude: renv/activate.R
+    - id: readme-rmd-rendered
+    - id: parsable-R
+    - id: no-browser-statement
+-   repo: local
+    hooks:
+    -   id: forbid-to-commit
+        name: Don't commit common R artifacts
+        entry: Cannot commit .Rhistory, .RData, .Rds or .rds.
+        language: fail
+        files: '\.Rhistory|\.RData|\.Rds|\.rds$'
+        # `exclude: <regex>` to allow committing specific files.
+{% endif -%}

--- a/{{ cookiecutter.repo_name }}/DESCRIPTION
+++ b/{{ cookiecutter.repo_name }}/DESCRIPTION
@@ -1,14 +1,12 @@
-Package: govcookiecutter
-Title: A Template Data Science Project
-Version: 0.0.0.9000
+Package: {{ cookiecutter.repo_name }}
+Title: {{ cookiecutter.project_name }}
+Version: {{ cookiecutter.project_version }}
 Authors@R:
-    person(given = "First",
-           family = "Last",
+    person(given = "{{ cookiecutter.organisation_name }}",
            role = c("aut", "cre"),
-           email = "first.last@example.com")
-Description: What the package does (one paragraph).
-License: `use_mit_license()`, `use_gpl3_license()` or friends to
-    pick a license
+           email = "{{ cookiecutter.contact_email }}")
+Description: {{ cookiecutter.overview }}
+License: MIT + file LICENSE
 Imports:
     docopt,
     git2r,

--- a/{{ cookiecutter.repo_name }}/DESCRIPTION
+++ b/{{ cookiecutter.repo_name }}/DESCRIPTION
@@ -1,0 +1,22 @@
+Package: govcookiecutter
+Title: A Template Data Science Project
+Version: 0.0.0.9000
+Authors@R:
+    person(given = "First",
+           family = "Last",
+           role = c("aut", "cre"),
+           email = "first.last@example.com")
+Description: What the package does (one paragraph).
+License: `use_mit_license()`, `use_gpl3_license()` or friends to
+    pick a license
+Imports:
+    docopt,
+    git2r,
+    lintr,
+    styler,
+    usethis
+Encoding: UTF-8
+Language: en-GB
+LazyData: true
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.0.0

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -16,7 +16,6 @@
 To start contributing to `{{ cookiecutter.repo_name }}`, run the following commands in your shell:
 
 ``` shell script
-git init
 make requirements
 ```
 

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -13,7 +13,12 @@
 
 ## Getting started
 
-To be added.
+To start contributing to `{{ cookiecutter.repo_name }}`, run the following commands in your shell:
+
+``` shell script
+git init
+make requirements
+```
 
 ### Requirements
 

--- a/{{ cookiecutter.repo_name }}/docs/structure/README.md
+++ b/{{ cookiecutter.repo_name }}/docs/structure/README.md
@@ -35,7 +35,7 @@ coverage run -m pytest
 coverage html
 ```
 
-a code coverage report in HTML will be produced on the code in the `src` folder. This HTMl report can be accessed at
+a code coverage report in HTML will be produced on the code in the `src` folder. This HTML report can be accessed at
 `htmlcov/index.html`.
 
 ### `.envrc`
@@ -136,6 +136,21 @@ Alternatively, to install the requirements file along with pre-commit hooks, run
 ```shell
 make requirements
 ```
+
+{%- if cookiecutter.add_r_precommit_hooks == "Yes" %}
+### `DESCRIPTION`
+Information related to the project including the name, authors and packages necessary for the project.
+
+### `startup.R`
+Installs necessary packages specified in the `DESCRIPTION` file upon starting R via `.Rprofile`.
+
+### `.Rprofile`
+Initialisation file that runs automatically when starting R.
+
+### `.lintr`
+Configuration file for styling R code that's used by pre-commit hooks to check R code.
+
+{% endif %}
 
 [code-of-conduct]:../contributor_guide/CODE_OF_CONDUCT.md
 [contributing]: ../contributor_guide/CONTRIBUTING.md

--- a/{{ cookiecutter.repo_name }}/docs/structure/README.md
+++ b/{{ cookiecutter.repo_name }}/docs/structure/README.md
@@ -137,20 +137,18 @@ Alternatively, to install the requirements file along with pre-commit hooks, run
 make requirements
 ```
 
-{%- if cookiecutter.add_r_precommit_hooks == "Yes" %}
 ### `DESCRIPTION`
-Information related to the project including the name, authors and packages necessary for the project.
+R-specific. Information related to the project including the name, authors and packages necessary for the project.
 
 ### `startup.R`
-Installs necessary packages specified in the `DESCRIPTION` file upon starting R via `.Rprofile`.
+R-specific. Installs necessary packages specified in the `DESCRIPTION` file upon starting R via `.Rprofile`.
 
 ### `.Rprofile`
-Initialisation file that runs automatically when starting R.
+R-specific. Initialisation file that runs automatically when starting R.
 
 ### `.lintr`
-Configuration file for styling R code that's used by pre-commit hooks to check R code.
+R-specific. Configuration file for styling R code that's used by pre-commit hooks to check R code.
 
-{% endif %}
 
 [code-of-conduct]:../contributor_guide/CODE_OF_CONDUCT.md
 [contributing]: ../contributor_guide/CONTRIBUTING.md

--- a/{{ cookiecutter.repo_name }}/startup.R
+++ b/{{ cookiecutter.repo_name }}/startup.R
@@ -1,5 +1,7 @@
-if(!require(devtools))
-    install.packages(pkgs = 'devtools', Ncpus = 1, repos='https://cran.ma.imperial.ac.uk/')
-
-# install packages from DESCRIPTION
-devtools::install()
+if (length(grep(pattern = "devtools", x = utils::installed.packages()[, 1])) == 0) {
+  Sys.setenv(R_PROFILE_USER = "/dev/null")
+  install.packages(pkgs = "devtools", Ncpus = 1, repos = "https://cran.ma.imperial.ac.uk/")
+  # install packages from DESCRIPTION file
+  devtools::install()
+  Sys.unsetenv("R_PROFILE_USER")
+}

--- a/{{ cookiecutter.repo_name }}/startup.R
+++ b/{{ cookiecutter.repo_name }}/startup.R
@@ -1,6 +1,6 @@
 if (length(grep(pattern = "devtools", x = utils::installed.packages()[, 1])) == 0) {
   Sys.setenv(R_PROFILE_USER = "/dev/null")
-  install.packages(pkgs = "devtools", Ncpus = 1, repos = "https://cran.ma.imperial.ac.uk/")
+  utils::install.packages(pkgs = "devtools", Ncpus = 1, repos = "https://cran.ma.imperial.ac.uk/")
   # install packages from DESCRIPTION file
   devtools::install()
   Sys.unsetenv("R_PROFILE_USER")

--- a/{{ cookiecutter.repo_name }}/startup.R
+++ b/{{ cookiecutter.repo_name }}/startup.R
@@ -1,0 +1,5 @@
+if(!require(devtools))
+    install.packages(pkgs = 'devtools', Ncpus = 1, repos='https://cran.ma.imperial.ac.uk/')
+
+# install packages from DESCRIPTION
+devtools::install()


### PR DESCRIPTION
# Summary
This branch adds R pre-commit hooks to the repo so data science projects that use Python **and** R will have pre-commit checks conducted on them.

# Check
- [ ] The R pre-commit hooks work
    + When you don't have `devtools` already installed
    + When you do have `devtools` already installed

A sample file. courtesy of @nacnudus, that triggers the hooks can be found below:

```r
# 3c266dcfef0f244d90685e45f9c1a6d91c4055be4c48c84161ffe9b7936ddc01 # Detect secrets
x = 2 # style-files
# trailing whitespace 
x
"/absolute/path" # lintr
library(styler # parsable-R
browser() # no-browser-statement
# No newline character at end of file
```

## Note
It's quite tricky using the `.Rprofile` to install packages, including those specified in the `DESCRIPTION` file upon loading R. The best solution was found [here](https://stackoverflow.com/a/55539569/13416265) which was especially useful in avoiding the invoking of infinite loops...

If you dislike the `.Rprofile` and `startup.R` method, there are two alternatives:

1. Request the user enters the below in their terminal before running any R code. This may require the user to set the path to R.
```r
R
install.packages(pkgs = 'devtools', Ncpus = 1)
devtools::install()
```
2.  Utilise `renv`. This requires the installation of many other packages so isn't exactly lightweight. However, abstracts the details of the installation of these pre-commit hooks well as the packages are downloaded and installed before the user starts R, plus it is throroughly tested.

## Previous work
This branch builds on the work done in #9, but simplifies it by just focussing on the pre-commit hooks. In #9, there was the continual risk that using `renv` would complicate the branch too much. Indeed, it does seem to add a few more packages to the repo.