### PR TITLE
Fix licences to assert Crown copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 UK Government Data Science
+Copyright (c) 2020 Crown copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/{{ cookiecutter.repo_name }}/LICENSE
+++ b/{{ cookiecutter.repo_name }}/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) {% now "Europe/London", "%Y" %} {{ cookiecutter.department_name }}
+Copyright (c) {% now "Europe/London", "%Y" %} Crown copyright ({{ cookiecutter.department_name }})
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Works made by Civil Servants come under Crown Copyright, according to the Copyright, Designs and Patents Act 1988; see [National Archives][national-archives] for an explanation, and link to the legislation.

[national-archives]: http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright/crown-copyright/