### PR TITLE
Update references to `master` branch to `main` branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ If you want to modify the `.gitignore` files, see the template [documentation][d
 details.
 
 Our source code is stored on GitHub at [https://github.com/ukgovdatascience/govcookiecutter][govcookiecutter]. Pull
-requests into `master` require at least one approved review.
+requests into `main` require at least one approved review.
 
 ### Python
 

--- a/{{ cookiecutter.repo_name }}/CONTRIBUTING.md
+++ b/{{ cookiecutter.repo_name }}/CONTRIBUTING.md
@@ -45,7 +45,7 @@ merges, as well as the entry on `git push --force-with-lease` instead of `git pu
 If you want to modify the `.gitignore` files, see the template [documentation][docs-updating-gitignore] for further
 details.
 
-Our source code is stored on {{ cookiecutter.repository_hosting_platform }}. Pull requests into `master` require at
+Our source code is stored on {{ cookiecutter.repository_hosting_platform }}. Pull requests into `main` require at
 least one approved review.
 
 ### Python


### PR DESCRIPTION
Base branch has been renamed from `master` to `main`. Changes need to be made to the documentation to reflect this.