### PR TITLE
Extend pre-commit hooks to include Google Colab notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     -   id: flake8
         args: ["hooks", "tests", "{{ cookiecutter.repo_name }}/src"]
 -   repo: https://github.com/Yelp/detect-secrets
-    rev: v0.14.3
+    rev: v1.0.3
     hooks:
     -   id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     - id: nbstripout
       args:
         - --extra-keys
-        - "metadata.kernelspec cell.metadata.executionInfo"
+        - "metadata.colab metadata.kernelspec cell.metadata.colab cell.metadata.executionInfo cell.metadata.id cell.metadata.outputId"
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,14 +12,13 @@ repos:
     -   id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
         exclude: .*/tests/.*
--   repo: https://github.com/aflc/pre-commit-jupyter
-    rev: v1.1.0
-    hooks:
-    -   id: jupyter-notebook-cleanup
-        args:
-        -   --remove-kernel-metadata
-        -   --pin-patterns
-        -   "[keep_output]"
+- repo: https://github.com/kynan/nbstripout
+  rev: 0.3.9
+  hooks:
+    - id: nbstripout
+      args:
+        - --extra-keys
+        - "metadata.kernelspec cell.metadata.executionInfo"
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,20 +1,18 @@
 {
-  "custom_plugin_paths": [],
-  "exclude": {
-    "files": null,
-    "lines": null
-  },
-  "generated_at": "2021-01-11T09:41:31Z",
+  "version": "1.0.3",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -23,8 +21,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3.0
     },
     {
       "name": "IbmCloudIamDetector"
@@ -36,11 +34,14 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
     },
     {
       "name": "PrivateKeyDetector"
@@ -52,16 +53,42 @@
       "name": "SoftlayerDetector"
     },
     {
+      "name": "SquareOAuthDetector"
+    },
+    {
       "name": "StripeDetector"
     },
     {
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
   "results": {},
-  "version": "0.14.3",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-03-04T17:23:56Z"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 cookiecutter
 coverage
 detect-secrets
-flake8
 myst-parser
 pre-commit
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cookiecutter
 coverage
-detect-secrets
+detect-secrets==1.0.3
 myst-parser
 pre-commit
 pytest

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     -   id: flake8
         args: ["src"]
 -   repo: https://github.com/Yelp/detect-secrets
-    rev: v0.14.3
+    rev: v1.0.3
     hooks:
     -   id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     - id: nbstripout
       args:
         - --extra-keys
-        - "metadata.kernelspec cell.metadata.executionInfo"
+        - "metadata.colab metadata.kernelspec cell.metadata.colab cell.metadata.executionInfo cell.metadata.id cell.metadata.outputId"
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -12,14 +12,13 @@ repos:
     -   id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
         exclude: .*/tests/.*
--   repo: https://github.com/aflc/pre-commit-jupyter
-    rev: v1.1.0
-    hooks:
-    -   id: jupyter-notebook-cleanup
-        args:
-        -   --remove-kernel-metadata
-        -   --pin-patterns
-        -   "[keep_output]"
+- repo: https://github.com/kynan/nbstripout
+  rev: 0.3.9
+  hooks:
+    - id: nbstripout
+      args:
+        - --extra-keys
+        - "metadata.kernelspec cell.metadata.executionInfo"
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:

--- a/{{ cookiecutter.repo_name }}/.secrets.baseline
+++ b/{{ cookiecutter.repo_name }}/.secrets.baseline
@@ -1,20 +1,18 @@
 {
-  "custom_plugin_paths": [],
-  "exclude": {
-    "files": null,
-    "lines": null
-  },
-  "generated_at": "2021-01-11T09:41:31Z",
+  "version": "1.0.3",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -23,8 +21,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3.0
     },
     {
       "name": "IbmCloudIamDetector"
@@ -36,11 +34,14 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
     },
     {
       "name": "PrivateKeyDetector"
@@ -52,16 +53,42 @@
       "name": "SoftlayerDetector"
     },
     {
+      "name": "SquareOAuthDetector"
+    },
+    {
       "name": "StripeDetector"
     },
     {
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
   "results": {},
-  "version": "0.14.3",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-03-04T17:23:56Z"
 }

--- a/{{ cookiecutter.repo_name }}/docs/contributor_guide/pre_commit_hooks.md
+++ b/{{ cookiecutter.repo_name }}/docs/contributor_guide/pre_commit_hooks.md
@@ -17,7 +17,8 @@ For this repository, we are using `pre-commit` for a number of purposes:
 - Checking for secrets being committed accidentally — see [here](#definition-of-a-secret-according-to-detect-secrets)
   for the definition of a "secret";
 - Checking for any large files (over 5 MB) being committed; and
-- Cleaning Jupyter notebooks, which means removing all outputs and execution counts.
+- Cleaning Jupyter notebooks, which means removing all outputs, execution counts, Python kernels, and, for Google
+  Colaboratory (Colab), stripping out user information.
 
 We have configured `pre-commit` to run automatically on _every commit_. By running on each commit, we ensure that
 `pre-commit` will be able to detect all contraventions and keep our repository in a healthy state.
@@ -93,17 +94,34 @@ updating and auditing the `.secrets.baseline` file.
 
 ## Keeping specific Jupyter notebook outputs
 
-It may be necessary or useful to keep certain output cells of a Jupyter notebook, for example charts or graphs
-visualising some set of data. To do this, add the following comment at the top of the input block:
+>  ℹ️ Currently (March 2020) there is no way to add tags and/or metadata to Google Colab notebooks. It's strongly
+> suggested that you download the Colab as a .ipynb file, and edit tags and/or metadata using Jupyter _before_
+> committing the code if you want to keep some outputs.
 
-```julia
-# [keep_output]
+It may be necessary or useful to keep certain output cells of a Jupyter notebook, for example charts or graphs
+visualising some set of data. To do this, according to the documentation for the [`nbstripout`][nbstripout] package,
+either:
+
+1. Add a `keep_output` tag to the desired cell; or
+2. Add `"keep_output": true` to the desired cell's metadata.
+
+You can access cell tags or metadata in Jupyter by enabling the "Tags" or "Edit Metadata" toolbar
+(View > Cell Toolbar > Tags; View > Cell Toolbar > Edit Metadata). For the tags approach, enter `keep_output` in the
+text field for each desired cell, and press the "Add tag" button. For the metadata approach, press the "Edit Metadata"
+button on each desired cell, and edit the metadata to look like this:
+
+```json
+{
+  "keep_output": true
+}
 ```
 
-This will tell the hook not to strip the resulting output of this cell, allowing it to be committed.
+This will tell the hook not to strip the resulting output of the desired cell(s), allowing the output(s) to be
+committed.
 
 [detect-secrets]: https://github.com/Yelp/detect-secrets
 [detect-secrets-caveats]: https://github.com/Yelp/detect-secrets#caveats
 [detect-secrets-keyword-detector]: https://github.com/Yelp/detect-secrets/blob/master/detect_secrets/plugins/keyword.py
 [detect-secrets-plugins]: https://github.com/Yelp/detect-secrets#currently-supported-plugins
+[nbstripout]: https://github.com/kynan/nbstripout
 [pre-commit]: https://pre-commit.com/

--- a/{{ cookiecutter.repo_name }}/docs/contributor_guide/pre_commit_hooks.md
+++ b/{{ cookiecutter.repo_name }}/docs/contributor_guide/pre_commit_hooks.md
@@ -23,6 +23,10 @@ For this repository, we are using `pre-commit` for a number of purposes:
 We have configured `pre-commit` to run automatically on _every commit_. By running on each commit, we ensure that
 `pre-commit` will be able to detect all contraventions and keep our repository in a healthy state.
 
+> ⚠️ **No pre-commit hooks will be run on Google Colab notebooks pushed directly to GitHub**. For security reasons, it
+> is highly recommended that you manually download your notebook, and commit up locally to ensure pre-commit hooks are
+> executed on your changes
+
 ## Installation
 
 In order for `pre-commit` to run, action is needed to configure it on your system.
@@ -77,19 +81,49 @@ contain words that will trip the KeywordDetector plugin; see the `DENYLIST` vari
 If `pre-commit` detects any secrets when you try to create a commit, it will detail what it found and where to go to
 check the secret.
 
-If the detected secret is a false-positive, you should update the `.secrets.baseline` through the following steps:
+If the detected secret is a false positive, there are two options to resolve this, and prevent your commit from being
+blocked: [inline allowlisting (recommended)](#inline-allowlisting-recommended) or
+[updating `.secrets.baseline`](#updating-secretsbaseline).
+
+In either case, if an actual secret is detected (or a combination of actual secrets and false positives), first remove
+the actual secret before following either of these processes.
+
+#### Inline allowlisting (recommended)
+
+To exclude a false positive, add a `pragma` comment such as:
+
+```python
+secret = "Password123"  # pragma: allowlist secret
+```
+
+or
+
+```python
+#  pragma: allowlist nextline secret
+secret = "Password123"
+```
+
+If the detected secret is actually a secret (or other sensitive information), remove the secret and re-commit; there is
+no need to add any `pragma` comments.
+
+If your commit contains a mixture of false positives and actual secrets, remove the actual secrets first before adding
+`pragma` comments to the false positives.
+
+#### Updating `.secrets.baseline`
+
+To exclude a false positive, you can also update the `.secrets.baseline` through the following steps:
 
 - Run `detect-secrets scan --baseline .secrets.baseline` from the root folder in the terminal to index the
-  false-positive(s);
+  false positive(s);
 - Next, audit all indexed secrets via `detect-secrets audit .secrets.baseline` (the same as during initial set-up, if a
   `.secrets.baseline` doesn't exist); and
-- Finally, ensure that you commit the updated `.secrets.baseline` in the same commit as the false-positive(s) it has
+- Finally, ensure that you commit the updated `.secrets.baseline` in the same commit as the false positive(s) it has
   been updated for.
 
 If the detected secret is actually a secret (or other sensitive information), remove the secret and re-commit. There is
 no need to update the `.secrets.baseline` file in this case.
 
-If your commit contains a mixture of false-positives and actual secrets, remove the actual secrets first before
+If your commit contains a mixture of false positives and actual secrets, remove the actual secrets first before
 updating and auditing the `.secrets.baseline` file.
 
 ## Keeping specific Jupyter notebook outputs

--- a/{{ cookiecutter.repo_name }}/docs/contributor_guide/pre_commit_hooks.md
+++ b/{{ cookiecutter.repo_name }}/docs/contributor_guide/pre_commit_hooks.md
@@ -94,10 +94,6 @@ updating and auditing the `.secrets.baseline` file.
 
 ## Keeping specific Jupyter notebook outputs
 
->  ℹ️ Currently (March 2020) there is no way to add tags and/or metadata to Google Colab notebooks. It's strongly
-> suggested that you download the Colab as a .ipynb file, and edit tags and/or metadata using Jupyter _before_
-> committing the code if you want to keep some outputs.
-
 It may be necessary or useful to keep certain output cells of a Jupyter notebook, for example charts or graphs
 visualising some set of data. To do this, according to the documentation for the [`nbstripout`][nbstripout] package,
 either:
@@ -118,6 +114,10 @@ button on each desired cell, and edit the metadata to look like this:
 
 This will tell the hook not to strip the resulting output of the desired cell(s), allowing the output(s) to be
 committed.
+
+>  ℹ️ Currently (March 2020) there is no way to add tags and/or metadata to Google Colab notebooks. It's strongly
+> suggested that you download the Colab as a .ipynb file, and edit tags and/or metadata using Jupyter _before_
+> committing the code if you want to keep some outputs.
 
 [detect-secrets]: https://github.com/Yelp/detect-secrets
 [detect-secrets-caveats]: https://github.com/Yelp/detect-secrets#caveats

--- a/{{ cookiecutter.repo_name }}/docs/contributor_guide/pre_commit_hooks.md
+++ b/{{ cookiecutter.repo_name }}/docs/contributor_guide/pre_commit_hooks.md
@@ -79,7 +79,7 @@ check the secret.
 
 If the detected secret is a false-positive, you should update the `.secrets.baseline` through the following steps:
 
-- Run `detect-secrets scan --update .secrets.baseline` from the root folder in the terminal to index the
+- Run `detect-secrets scan --baseline .secrets.baseline` from the root folder in the terminal to index the
   false-positive(s);
 - Next, audit all indexed secrets via `detect-secrets audit .secrets.baseline` (the same as during initial set-up, if a
   `.secrets.baseline` doesn't exist); and

--- a/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/{{ cookiecutter.repo_name }}/requirements.txt
@@ -1,6 +1,5 @@
-detect-secrets
 coverage
-flake8
+detect-secrets
 myst-parser
 pre-commit
 pytest

--- a/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/{{ cookiecutter.repo_name }}/requirements.txt
@@ -1,5 +1,5 @@
 coverage
-detect-secrets
+detect-secrets==1.0.3
 myst-parser
 pre-commit
 pytest


### PR DESCRIPTION
# Summary

Google Colab notebooks have additional cell metadata that is **not** removed by the `pre-commit-jupyter` hook. Specifically, this cell metadata can include a user's full name, profile picture, and other personally-identifiable information.

To mitigate this, I have replaced `pre-commit-jupyter` with `nbstripout`, which has the added functionality of letting you specify what metadata to remove. I have tried to replicate the only extra change that `pre-commit-jupyter` makes (AFAIK), which is removing the `metadata.kernelspec` metadata; `nbstripout` is slightly different as it only deletes metadata, and does not replace entries like `pre-commit-jupyter`.

I also updated `detect-secrets` to the latest version, and updated `.secrets.baseline` and documentation accordingly. Due to contributors needing to have `detect-secrets` installed for scanning/auditing purposes, I've mandated the version in `requirements.txt`. This is not the case for `flake8`, so I have removed this from `requirements.txt`, since it is installed directly by `pre-commit`.

## Developer Testing

I've tested this using `pre-commit-jupyter`'s [test notebook](https://github.com/roy-ht/pre-commit-jupyter/blob/master/notebooks/test.ipynb) - note the way `nbstripout` keeps output cells is different.

I then used a pre-existing Google Colab notebook to check that the outputs were stripped, along with the kernel, and the user information. Note that keeping outputs is only possible via Jupyter, but Colab will preserve the tags/additional metadata (see updated documentation). After stripping outputs/metadata, I then loaded the notebook back in Google Colab to check it worked, and re-downloaded it again to ensure `keep_output` tags and metadata were retained.

`detect-secrets` was tested by deliberately trying to commit a secret-like variable in a tracked file on a throwaway branch (to trip the hook), scanning the baseline using the new command `detect-secrets scan --baseline .secrets.baseline`, then auditing the baseline. Once completed I was able to successfully commit a secret-like variable, as expected.

# Checklists

<!--
These are DO-CONFIRM checklists; it CONFIRMs that you have DOne each item.

Outstanding actions should be completed before reviewers are assigned; if actions are irrelevant, please try and add a
comment stating why.

Incomplete pull/merge requests MAY be blocked until actions are resolved, or closed at the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [x] Code runs
- [x] Developments are **secure** and [**ethical**][data-ethics-framework]
- [x] You have made proportionate checks that the code works correctly
- [x] Test suite passes
- [x] [Minimum usable documentation][agilemodeling] written in the `docs` folder

Comments have been added below around the incomplete checks.

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework