### PR TITLE
Fix incorrect documentation reference to organisation owner

### DIFF
--- a/{{ cookiecutter.repo_name }}/docs/structure/README.md
+++ b/{{ cookiecutter.repo_name }}/docs/structure/README.md
@@ -84,8 +84,8 @@ the user deliberately wishes to commit the to repository.
 
 ### `CODE_OF_CONDUCT.md`
 
-The [Code of Conduct][code-of-conduct] for contributors to this project, including maintainers and `ukgovdatascience`
-organisation owners.
+The [Code of Conduct][code-of-conduct] for contributors to this project, including maintainers and
+`{{ cookiecutter.organisation_name }}` organisation owners.
 
 ### `conftest.py`
 


### PR DESCRIPTION
Minor documentation fix - left in a hardcoded reference to `ukgovdatascience`, when this should be a Jinja2 placeholder.