### PR TITLE
Use latest R {precommit} version

### DIFF
--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
 {% if cookiecutter.using_R == "Yes" %}
   # R specific hooks: https://github.com/lorenzwalthert/precommit
   - repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.1.3
+    rev: v0.1.3.9014
     hooks:
       - id: style-files
         name: Style files using styler


### PR DESCRIPTION
This prepares for a transition to virtual environments with `language: r` (https://github.com/lorenzwalthert/precommit/blob/master/NEWS.md)

# Summary

I think it's best to use the up-to-date revision for R pre-commit hooks. I hope you have CI/CD to check if this works.

Disclosure: I am the maintainer of the R package precommit.

# Checklists

This pull/merge request meets the following requirements:

- [ ] code runs
- [x] [developments are ethical][data-ethics-framework] and secure
- [x] you have made proportionate checks that the code works correctly
- [ ] you have tested the build of the template
- [ ] test suite passes
- [x] [minimum usable documentation][agilemodeling] written in the `docs` folder

Comments have been added below around the incomplete checks.

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
