### PR TITLE
Fix GitHub actions for patches

### DIFF
--- a/.github/workflows/govcookiecutter-build.yml
+++ b/.github/workflows/govcookiecutter-build.yml
@@ -1,6 +1,6 @@
 name: govcookiecutter build
 
-on: [ push ]
+on: [ push, pull_request ]
 
 jobs:
   build:
@@ -12,7 +12,8 @@ jobs:
         python: [ 3.6, 3.7, 3.8, 3.9 ]
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout the revision
+        uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/govcookiecutter-template-build.yml
+++ b/.github/workflows/govcookiecutter-template-build.yml
@@ -18,6 +18,10 @@ jobs:
           - {using_R: Yes, version: 4.1.0}
 
     steps:
+      - name: Checkout the revision
+        uses: actions/checkout@v2
+        with:
+          path: ga-govcookiecutter
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2
         with:
@@ -45,9 +49,7 @@ jobs:
           fi;
         shell: bash
       - name: Create project from govcookiecutter for this commit
-        run: |
-          # Relies on the repository being public
-          cookiecutter ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git --no-input --checkout ${GITHUB_HEAD_REF} repo_name=example using_R=${{ matrix.R.using_R }}
+        run: cookiecutter ga-govcookiecutter --no-input repo_name=example using_R=${{ matrix.R.using_R }}
         shell: bash
       - name: Install requirements, and pre-commit hooks, and check Sphinx build
         run: |


### PR DESCRIPTION
# Summary

Fixes a bug in the GitHub Actions where pull requests submitted by contributors through forks fail CI checks.

Should fix Issue #40.

# Checklists

<!--
These are DO-CONFIRM checklists; it CONFIRMs that you have DOne each item.

Outstanding actions should be completed before reviewers are assigned; if actions are
irrelevant, please try and add a comment stating why.

Incomplete pull/merge requests MAY be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [x] code runs
- [x] [developments are ethical][data-ethics-framework] and secure
- [x] you have made proportionate checks that the code works correctly
- [x] you have tested the build of the template
- [x] test suite passes
- [ ] ~~[minimum usable documentation][agilemodeling] written in the `docs` folder~~ - not required

Comments have been added below around the incomplete checks.

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
