### PR TITLE
Revert "Use latest R {precommit} version"

### DIFF
--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
 {% if cookiecutter.using_R == "Yes" %}
   # R specific hooks: https://github.com/lorenzwalthert/precommit
   - repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.1.3.9014
+    rev: v0.1.3
     hooks:
       - id: style-files
         name: Style files using styler


### PR DESCRIPTION
Reverting to v0.1.3 of the R {precommit} package, as we are missing some dependencies (outside of the fix made in PR #41), which are causing the GitHub Actions to fail.