### PR TITLE
Prepare project for transfer to ONS Best Practice and Impact team

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,8 @@
 # Code of conduct for `govcookiecutter`
 
-Contributors to this repository hosted by `ukgovdatascience` are expected to follow the
-Contributor Covenant Code of Conduct. Contributors working within Her Majesty's
-Government are also expected to follow the Civil Service Code.
+Contributors to this repository hosted by `best-practice-and-impact` are expected to
+follow the Contributor Covenant Code of Conduct. Contributors working within Her
+Majesty's Government are also expected to follow the Civil Service Code.
 
 ## Civil Service Code
 
@@ -16,9 +16,9 @@ Code][civil-service-code], and are expected to follow it in their contributions.
 Where this Code of Conduct says:
 
 - "Project", we mean this `govcookiecutter` GitHub repository;
-- "Maintainer", we mean the `ukgovdatascience` organisation owners; and
-- "Leadership", we mean both `ukgovdatascience` organisation owners, line managers, and
-  other leadership within the Government Digital Service.
+- "Maintainer", we mean the `best-practice-and-impact` organisation owners; and
+- "Leadership", we mean both `best-practice-and-impact` organisation owners, line
+  managers, and other leadership within the Office for National Statistics.
 
 ### Our Pledge
 
@@ -73,7 +73,7 @@ further defined and clarified by project maintainers.
 
 Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by
 contacting the project team at
-[gds-data-science@digital.cabinet-office.gov.uk][email-address]. All complaints will be
+[gsshelp@statistics.gov.uk][email-address]. All complaints will be
 reviewed and investigated and will result in a response that is deemed necessary and
 appropriate to the circumstances. The project team is obligated to maintain
 confidentiality with regard to the reporter of an incident. Further details of
@@ -95,4 +95,4 @@ and the `alphagov` Code of Conduct available at
 [civil-service-code]: https://www.gov.uk/government/publications/civil-service-code/the-civil-service-code
 [contributor-covenant]: https://www.contributor-covenant.org
 [contributor-covenant-code-of-conduct]: https://www.contributor-covenant.org/version/1/4/code-of-conduct/
-[email-address]: mailto:gds-data-science@digital.cabinet-office.gov.uk
+[email-address]: mailto:gsshelp@statistics.gov.uk

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ Git best practice][gds-way-git]. This includes how to write good commit messages
 documentation][docs-updating-gitignore] for further details.
 
 Our source code is stored on GitHub at
-[https://github.com/ukgovdatascience/govcookiecutter][govcookiecutter]. Pull requests
-into `main` require at least one approved review.
+[https://github.com/best-practice-and-impact/govcookiecutter][govcookiecutter]. Pull
+requests into `main` require at least one approved review.
 
 ### Python
 
@@ -129,11 +129,11 @@ the `README.md` file in that folder.
 [docs-updating-gitignore]: ./%7B%7B%20cookiecutter.repo_name%20%7D%7D/docs/contributor_guide/updating_gitignore.md
 [docs-write-accessible-documentation]: ./%7B%7B%20cookiecutter.repo_name%20%7D%7D/docs/contributor_guide/writing_accessible_documentation.md
 [docs-write-sphinx-documentation]: ./%7B%7B%20cookiecutter.repo_name%20%7D%7D/docs/contributor_guide/writing_sphinx_documentation.md
-[email]: mailto:gds-data-science@digital.cabinet-office.gov.uk
+[email]: mailto:gsshelp@statistics.gov.uk
 [gds-way]: https://gds-way.cloudapps.digital/
 [gds-way-git]: https://gds-way.cloudapps.digital/standards/source-code.html
 [gds-way-python]: https://gds-way.cloudapps.digital/manuals/programming-languages/python/python.html#python-style-guide
-[govcookiecutter]: https://github.com/ukgovdatascience/govcookiecutter
+[govcookiecutter]: https://github.com/best-practice-and-impact/govcookiecutter
 [myst]: https://myst-parser.readthedocs.io/
 [pre-commit]: https://pre-commit.com/
 [pytest]: https://docs.pytest.org/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2020 Crown copyright (Government Digital Service)
+Copyright (c) 2020 Crown copyright (Government Digital Service,
+Office for National Statistics)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ terminal, navigate to the directory where you want your new repository to exist.
 run the following command for the latest stable release:
 
 ```shell
-cookiecutter https://github.com/ukgovdatascience/govcookiecutter.git
+cookiecutter https://github.com/best-practice-and-impact/govcookiecutter.git
 ```
 
 or for a specific branch, tag, or commit SHA `{SPECIFIC}`, run:
 
 ```shell
-cookiecutter https://github.com/ukgovdatascience/govcookiecutter.git --checkout {SPECIFIC}
+cookiecutter https://github.com/best-practice-and-impact/govcookiecutter.git --checkout {SPECIFIC}
 ```
 
 Follow the prompts; if you are asked to re-download `govcookiecutter`, input `yes`.
@@ -114,7 +114,7 @@ Here are some suggested changes to make before your first commit:
   releases][cruft]
   ```shell
   pip install cruft
-  cruft link https://github.com/ukgovdatascience/govcookiecutter
+  cruft link https://github.com/best-practice-and-impact/govcookiecutter
   ```
 - make sure the `README.md` reflects what you want to do with your project
 - have a look inside the `docs/aqa` folder, as you may want to modify some of this
@@ -148,6 +148,6 @@ and a modified version of the `help` commands in the `Makefile`s.
 [docs-pre-commit]: ./%7B%7B%20cookiecutter.repo_name%20%7D%7D/docs/contributor_guide/pre_commit_hooks.md
 [drivendata]: http://drivendata.github.io/cookiecutter-data-science/
 [homebrew]: https://brew.sh/
-[issue-windows-os]: https://github.com/ukgovdatascience/govcookiecutter/issues/20
+[issue-windows-os]: https://github.com/best-practice-and-impact/govcookiecutter/issues/20
 [pluralsight]: https://www.pluralsight.com/tech-blog/managing-python-environments/
 [youtube]: https://www.youtube.com/watch?v=N7_d3k3uQ_M

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -4,9 +4,9 @@ orphan: true
 # Accessibility statement
 
 This accessibility statement applies to content published on the
-[ukgovdatascience.github.io/govcookiecutter][github-pages] domain.
+[best-practice-and-impact.github.io/govcookiecutter][github-pages] domain.
 
-This website is run by the Government Digital Service. We want as many people as
+This website is run by the Office for National Statistics. We want as many people as
 possible to be able to use this website. For example, that means you should be able to:
 
 - change colours, contrast levels and fonts
@@ -34,7 +34,7 @@ We know some parts of this website are not fully accessible:
 If you need information on this website in a different format like accessible PDF,
 large print, easy read, audio recording or braille:
 
-- email [gds-data-science@digital.cabinet-office.gov.uk][email]
+- email [gsshelp@statistics.gov.uk][email]
 - raise an issue on the [`govcookiecutter` GitHub repository][github-issues]
 
 ## Reporting accessibility problems with this website
@@ -52,7 +52,7 @@ complaint, [contact the Equality Advisory and Support Service (EASS)][eass].
 
 ## Technical information about this website's accessibility
 
-The Government Digital Service is committed to making its website accessible, in
+The Office for National Statistics is committed to making its website accessible, in
 accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2)
 Accessibility Regulations 2018.
 
@@ -87,14 +87,14 @@ codebase develops.
 The [Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility
 Regulations 2018 legislation][accessibility-legislation] does not require us to fix
 external, third-party websites that are neither funded nor developed by, nor under the
-control of the Government Digital Service (GDS).
+control of the Office for National Statistics (ONS).
 
 ## How we tested this website
 
-The test was carried out by the data science team at GDS. We used the [WAVE Web
-Accessibility Evaluation Tool][wave] and a checklist created by the GDS technical
-writing team with help from the GDS accessibility team. We tested all pages on this
-site.
+The test was carried out by the data science team at the Government Digital Service
+(GDS). They used the [WAVE Web Accessibility Evaluation Tool][wave] and a checklist
+created by the GDS technical writing team with help from the GDS accessibility team.
+They tested all pages on this site.
 
 ## What we're doing to improve accessibility
 
@@ -102,14 +102,14 @@ We plan to fix the accessibility issues in the content by the end of December 20
 
 ## Preparation of this accessibility statement
 
-This statement was prepared on 30 June 2021. It was last reviewed on 8 July 2021.
+This statement was prepared on 30 June 2021. It was last reviewed on 20 July 2021.
 
 [abilitynet]: https://mcmw.abilitynet.org.uk/
 [accessibility-legislation]: https://www.legislation.gov.uk/uksi/2018/952/regulation/4/made
 [eass]: https://www.equalityadvisoryservice.com/
-[email]: mailto:gds-data-science@digital.cabinet-office.gov.uk
-[github-issues]: https://github.com/ukgovdatascience/govcookiecutter/issues/new
-[github-pages]: https://ukgovdatascience.github.io/govcookiecutter
+[email]: mailto:gsshelp@statistics.gov.uk
+[github-issues]: https://github.com/best-practice-and-impact/govcookiecutter/issues/new
+[github-pages]: https://best-practice-and-impact.github.io/govcookiecutter
 [sphinx-autodoc]: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
 [sphinx-autosummary]: https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html
 [wave]: https://wave.webaim.org/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "govcookiecutter"
-author = "Government Digital Service"
+author = "Office for National Statistics"
 
 # List of patterns, relative to source directory, that match files and directories to
 # ignore when looking for source files. These patterns also affect html_static_path and
@@ -65,7 +65,7 @@ html_theme = "govuk_tech_docs_sphinx_theme"
 
 # Variables to pass to each HTML page to help populate page-specific options
 html_context = {
-    "github_url": "https://www.github.com/ukgovdatascience/govcookiecutter",
+    "github_url": "https://www.github.com/best-practice-and-impact/govcookiecutter",
     "gitlab_url": None,
     "conf_py_path": "docs/",
     "version": "main",
@@ -74,7 +74,7 @@ html_context = {
 
 # Theme options are theme-specific and customize the look and feel of a theme further.
 # For a list of options available for each theme, see the documentation.
-html_theme_options = {"organisation": "GDS", "phase": "Alpha"}
+html_theme_options = {"organisation": "ONS", "phase": "Alpha"}
 
 # Add any paths that contain custom static files (such as style sheets) here, relative
 # to this directory. They are copied after the builtin static files, so a file named

--- a/docs/contributing_guide/modify_govcookiecutter.md
+++ b/docs/contributing_guide/modify_govcookiecutter.md
@@ -14,7 +14,7 @@ variables are based on answers to prompts when you run the `cookiecutter` comman
 When you open your terminal and run:
 
 ```shell
-cookiecutter https://github.com/ukgovdatascience/govcookiecutter.git
+cookiecutter https://github.com/best-practice-and-impact/govcookiecutter.git
 ```
 
 you'll see a list of prompts to answer; one of them is `repo_name`.
@@ -208,7 +208,7 @@ select a different version of `govcookiecutter` to use based on their individual
 
 [cookiecutter]: https://cookiecutter.readthedocs.io
 [docs-organisational-frameworks]: ../%7B%7B%20cookiecutter.repo_name%20%7D%7D/.govcookiecutter/organisational_frameworks/README.md
-[github-issues]: https://github.com/ukgovdatascience/govcookiecutter/issues
+[github-issues]: https://github.com/best-practice-and-impact/govcookiecutter/issues
 [html5-email-format]: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
 [jinja]: https://jinja.palletsprojects.com
 [semver]: https://semver.org/

--- a/docs/structure/README.md
+++ b/docs/structure/README.md
@@ -41,7 +41,7 @@ wishes to commit the to repository.
 ### `CODE_OF_CONDUCT.md`
 
 [The Code of Conduct for contributors to this project][code-of-conduct], including
-maintainers and `ukgovdatascience` organisation owners.
+maintainers and `best-practice-and-impact` organisation owners.
 
 ### `conftest.py`
 

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -65,6 +65,6 @@ contributing guidelines][contributing].
 project][govcookiecutter].
 
 [contributing]: ./docs/contributor_guide/CONTRIBUTING.md
-[govcookiecutter]: https://github.com/ukgovdatascience/govcookiecutter
+[govcookiecutter]: https://github.com/best-practice-and-impact/govcookiecutter
 [docs-loading-environment-variables]: ./docs/user_guide/loading_environment_variables.md
 [docs-loading-environment-variables-secrets]: ./docs/user_guide/loading_environment_variables.md#storing-secrets-and-credentials

--- a/{{ cookiecutter.repo_name }}/docs/contributor_guide/writing_accessible_documentation.md
+++ b/{{ cookiecutter.repo_name }}/docs/contributor_guide/writing_accessible_documentation.md
@@ -36,9 +36,10 @@ rendered as a website using Sphinx.
   - [use accessible SVGs][govuk-design-system-images]
   - [check for inaccessible formats][govuk-accessible-formats]
 
-This checklist was created by the GDS technical writing team with help from the GDS
-accessibility team. We then [draft a suitable accessibility statement for the project;
-an example is available on GOV.UK][govuk-sample-accessibility].
+This checklist was created by the Government Digital Service (GDS) technical writing
+team with help from the GDS accessibility team. We then [draft a suitable accessibility
+statement for the project; an example is available on
+GOV.UK][govuk-sample-accessibility].
 
 [alex-js]: https://alexjs.com/
 [docs-write-sphinx-documentation]: ./writing_sphinx_documentation.md


### PR DESCRIPTION
# Summary

The ONS Best Practice and Impact team will be taking over maintenance of `govcookiecutter`.

This commit changes all relevant instances of `Government Digital Service`, `GDS`, and `ukgovdatascience` to `Office for National Statistics`, `ONS`, and `best-practice-and-impact`. The contact email has also been replaced.

# Checklists

<!--
These are DO-CONFIRM checklists; it CONFIRMs that you have DOne each item.

Outstanding actions should be completed before reviewers are assigned; if actions are
irrelevant, please try and add a comment stating why.

Incomplete pull/merge requests MAY be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [x] code runs
- [x] [developments are ethical][data-ethics-framework] and secure
- [x] you have made proportionate checks that the code works correctly
- [x] you have tested the build of the template
- [ ] test suite passes
- [x] [minimum usable documentation][agilemodeling] written in the `docs` folder

## Test failures

@alexander-newton for information.

It's likely the CI tests will fail for this PR, as GitHub Actions checks for valid links. In this case, there are unlikely to be valid links, as `govcookiecutter` does not yet exist on the `best-practice-and-impact` GitHub organisation.

There are three options to resolve this once you've completed the review:

1. ignore the failing checks, merge the PR, and then transfer the repository to the `best-practice-and-impact` GitHub organisation
2. transfer the repository to the `best-practice-and-impact` GitHub organisation first, deploy the documentation on GitHub Pages, re-run the GitHub Actions using the "Actions" tab above, and then merge the PR
3. create a fork on the `best-practice-and-impact` organisation, deploy the documentation on GitHub Pages, re-run the GitHub Actions on this repository, merge the PR, delete the fork, and transfer the repository over to the `best-practice-and-impact` organisation 

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
